### PR TITLE
Add Docker support for CaneBane Board

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+client/node_modules
+server/node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Multi-stage build for CaneBane Board
+FROM node:18-bullseye AS build
+
+# Set working directory
+WORKDIR /app
+
+# Copy source
+COPY . .
+
+# Install server dependencies
+WORKDIR /app/server
+RUN npm ci
+
+# Install client dependencies and build
+WORKDIR /app/client
+RUN npm ci \
+    && npm run build
+
+# Production image
+FROM node:18-bullseye
+WORKDIR /app
+
+# Copy server and built client from build stage
+COPY --from=build /app/server /app/server
+COPY --from=build /app/client/build /app/server/public
+
+# Install only production dependencies in server
+WORKDIR /app/server
+RUN npm prune --omit=dev
+
+# Expose port and start server
+EXPOSE 5000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -118,3 +118,15 @@ If you'd like to contribute to this project, please fork the repository and crea
 ## License
 
 This project is licensed under the MIT License.
+
+## Docker
+
+To run the application with Docker:
+
+1. Ensure Docker and Docker Compose are installed.
+2. Build and start the containers:
+   ```
+   docker-compose up --build
+   ```
+3. The server will be available at `http://localhost:5000` and will connect to a MongoDB instance provided by the compose file.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  canebane:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      PORT: 5000
+      MONGODB_URI: mongodb://mongodb:27017/canebane
+      JWT_SECRET: bB&7!dK*8Tp^3zL%fY9Qw@X#ErCgGhVr2Mt=+Js
+    depends_on:
+      - mongodb
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+volumes:
+  mongodb_data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build client and server
- add docker-compose with MongoDB service
- document Docker usage and ignore node_modules during image build

## Testing
- `npm test --prefix client` *(fails: Jest encountered an unexpected token)*
- `npm test --prefix server` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad1449b4d083298c702419c59df12e