### PR TITLE
Add Docker support for CaneBane Board

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+client/node_modules
+server/node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Multi-stage build for CaneBane Board
+FROM node:18-bullseye AS build
+
+# Set working directory
+WORKDIR /app
+
+# Copy source
+COPY . .
+
+# Install server dependencies
+WORKDIR /app/server
+RUN npm ci
+
+# Install client dependencies and build
+WORKDIR /app/client
+RUN npm ci \
+    && npm run build
+
+# Production image
+FROM node:18-bullseye
+WORKDIR /app
+
+# Copy server and built client from build stage
+COPY --from=build /app/server /app/server
+COPY --from=build /app/client/build /app/server/public
+
+# Install only production dependencies in server
+WORKDIR /app/server
+RUN npm prune --omit=dev
+
+# Expose port and start server
+EXPOSE 5000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Before you begin, ensure you have the following installed on your system:
    JWT_SECRET=your_secret_key_here
    ```
    Replace `your_secret_key_here` with a secure random string.
+   When running via Docker Compose, the server will fall back to
+   `mongodb://mongodb:27017/canebane` if `MONGODB_URI` is not set.
 
 4. Start MongoDB on your local machine.
 
@@ -118,3 +120,15 @@ If you'd like to contribute to this project, please fork the repository and crea
 ## License
 
 This project is licensed under the MIT License.
+
+## Docker
+
+To run the application with Docker:
+
+1. Ensure Docker and Docker Compose are installed.
+2. Build and start the containers:
+   ```
+   docker-compose up --build
+   ```
+3. The server will be available at `http://localhost:5000` and will connect to a MongoDB instance provided by the compose file.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  canebane:
+    build: .
+    ports:
+      - "5000:5000"
+      environment:
+        PORT: "5000"
+        MONGODB_URI: "mongodb://mongodb:27017/canebane"
+        JWT_SECRET: "development_secret"
+    depends_on:
+      - mongodb
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+volumes:
+  mongodb_data:

--- a/server/app.js
+++ b/server/app.js
@@ -13,8 +13,12 @@ const app = express(); // Create an instance of the express application
 app.use(cors()); // Enable CORS for all routes
 app.use(express.json()); // Parse incoming JSON requests
 
-// Connect to MongoDB using the URI from environment variables
-mongoose.connect(process.env.MONGODB_URI, {
+// Determine the MongoDB connection string. Default to the Docker Compose
+// service name when MONGODB_URI is not provided.
+const mongoURI = process.env.MONGODB_URI || 'mongodb://mongodb:27017/canebane';
+
+// Connect to MongoDB using the resolved URI
+mongoose.connect(mongoURI, {
   useNewUrlParser: true, // Use the new URL parser
   useUnifiedTopology: true, // Use the new unified topology layer
 });

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,11 +1,15 @@
 const mongoose = require('mongoose'); // Import mongoose for MongoDB object modeling
 require('dotenv').config(); // Load environment variables from .env file
 
+// Determine the MongoDB connection string. Default to the Docker Compose
+// service name when MONGODB_URI is not provided.
+const mongoURI = process.env.MONGODB_URI || 'mongodb://mongodb:27017/canebane';
+
 // Function to connect to the MongoDB database
 const connectDB = async () => {
   try {
-    // Connect to MongoDB using the URI from environment variables
-    await mongoose.connect(process.env.MONGODB_URI, {
+    // Connect to MongoDB using the resolved URI
+    await mongoose.connect(mongoURI, {
       useNewUrlParser: true, // Use the new URL parser
       useUnifiedTopology: true, // Use the new unified topology layer
     });


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build client and server
- add docker-compose with MongoDB service
- document Docker usage and ignore node_modules during image build
- quote docker-compose environment variables to ensure they parse correctly
- fall back to the Docker MongoDB service when `MONGODB_URI` is unset and replace the example JWT secret

## Testing
- `CI=true npm test --prefix client` *(fails: Jest encountered an unexpected token)*
- `npm test --prefix server` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad1449b4d083298c702419c59df12e